### PR TITLE
add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+tensorflow==2.3.1
+tensorflow-probability==0.11.1
+tensorflow-addons==0.11.2
+msprime==0.7.4
+stdpopsim==0.1.2
+zarr==2.4.0
+imageio==2.9.0
+seaborn==0.11.0
+matplotlib==3.3.2
+scikit-learn==0.23.2


### PR DESCRIPTION
This makes it easy for folks to install known-working dependencies with `pip install -r requirements.txt`.