### PR TITLE
Work in linear scale | Removed the Gaussian trick

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ In a standard GAN, two neural networks called the Discriminator (D) and the Gene
 
 The script genobuilder.py contains the tools to create a Genobuilder() object. This data object can generate genotype matrices from variant data under a demographic scenario. The data can be generated from different sources, such as msprime, stdpopsim and empirical data coming from VCF files. The script can be run in the console, with a command like:
 
-> python genobuilder.py download_genmats -s msprime -n 1000 -nh 99 -l 1e6 -maf 0.05 -f 128 -se 2020 -o my_geno
+> python genobuilder.py download_genmats -s msprime -n 1000 -nh 99 -l 1e6 -maf 0.05 -f 128 -se 2020 -o my_geno -p 16
 
 Or using the long flags:
 
-> python genobuilder.py download_genmats --source msprime --num-rep 1000  --number-haplotypes 99 --sequence.length 1e6 --maf-threshold 0.05 --fixed-dimension 128 --seed 2020 --output my_geno
+> python genobuilder.py download_genmats --source msprime --num-rep 1000  --number-haplotypes 99 --sequence.length 1e6 --maf-threshold 0.05 --fixed-dimension 128 --seed 2020 --output my_geno --parallelism 16
 
 The different arguments and flags are:
 
@@ -25,15 +25,17 @@ The different arguments and flags are:
 
 - **-l/--sequence-length:** Length of the randomly sampled genome region in bp. Default is 1000000 (1e6).
 
-- **-maf/--maf-threshold:** Threshold for the minor allele frequency to filter rare variants. Default is 0.05
+- **-maf/--maf-threshold:** Threshold for the minor allele frequency to filter rare variants. Default is 0.05.
 
-- **-f/--fixed-dimension:** Number of columns to rescale the genmats after sampling the sequence. Default is 128
+- **-f/--fixed-dimension:** Number of columns to rescale the genmats after sampling the sequence. Default is 128.
 
 - **-n/--num-rep:** Number of genotype matrices to generate.
 
 - **-se/--seed:** Seed for stochastic parts of the algorithm for reproducibility.
 
 - **-o/--output:** Name of the output file with the downloaded genobuilder pickle object "*\*.pkl*". In case of "download_genmats" function, the genotype matrices are stored in the "*\*_data.pkl*" file.
+
+- **-p/--parallelism:** Number of cores to use for simulation. If set to zero, os.cpu_count() is used. Default is 0.
 
 For simplicity, the default parameters work pretty good, so we recommend to run:
 
@@ -44,11 +46,11 @@ For simplicity, the default parameters work pretty good, so we recommend to run:
 
 The script genomcmcgan.py contains the tool to run and train the MCMC-GAN model. To run the code, first the user need to generate a pickled file containing a genotype object (using genobuilder.py). Optionally, the user can also provide a pickle object containing a set of genotype matrices previously generated. The script can be run in the console, with a command like:
 
-> python genomcmcgan.py my_geno.pkl -d geno_data.pkl -k hmc -e 10 -n 100 -b 50 -se 2020
+> python genomcmcgan.py my_geno.pkl -d geno_data.pkl -k hmc -e 10 -n 100 -b 50 -se 2020 -p 16
 
 Or using the long flags:
 
-> python genomcmcgan.py my_geno.pkl --data-path my_geno_data.pkl --kernel-name hmc --epochs 10 --num-mcmc-samples 100 --num-mcmc-burnin 50 --seed 2020
+> python genomcmcgan.py my_geno.pkl --data-path my_geno_data.pkl --kernel-name hmc --epochs 10 --num-mcmc-samples 100 --num-mcmc-burnin 50 --seed 2020 --parallelism 16
 
 The different arguments and flags are:
 
@@ -67,6 +69,8 @@ The different arguments and flags are:
 - **-n/--num-mcmc-burnin:** Number of MCMC burn-in steps in each training iteration of MCMCGAN.
 
 - **-se/--seed:** Seed for stochastic parts of the algorithm for reproducibility.
+
+- **-p/--parallelism:** Number of cores to use for simulation. If set to zero, os.cpu_count() is used. Default is 0.
 
 
 ## Library requirements:

--- a/genobuilder.py
+++ b/genobuilder.py
@@ -1,5 +1,4 @@
 import os
-from contextlib import contextmanager
 from collections import OrderedDict
 import concurrent.futures
 import msprime
@@ -16,35 +15,40 @@ from parameter import Parameter
 
 _ex = None
 
+
 def executor(p):
     global _ex
     if _ex is None:
         _ex = concurrent.futures.ProcessPoolExecutor(max_workers=p)
     return _ex
 
+
 def do_sim(args):
-    genob, params, randomize, gauss, seed = args
+    genob, params, randomize, i, proposals, seed = args
     rng = random.Random(seed)
 
-    Ne, mu, r = [
-        params[param].rand(gauss) if randomize else params[param].val
-        for param in ("effective size", "mutation rate", "recombination rate")
-    ]
+    if proposals:
+        Ne, mu, r = [
+            params[p].prop(i) if params[p].inferable else params[p].val
+            for p in ("effective size", "mutation rate", "recombination rate")
+        ]
+    else:
+        Ne, mu, r = [
+            params[p].rand() if randomize else params[p].val
+            for p in ("effective size", "mutation rate", "recombination rate")
+        ]
 
     ts = msprime.simulate(
-            sample_size=genob.num_samples,
-            Ne=Ne,
-            length=genob.seq_len,
-            mutation_rate=mu,
-            recombination_rate=r,
-            random_seed=rng.randrange(1, 2**32),
-        )
-    m = genob._resize_from_ts(ts, rng)
-    # Scale genotype matrices from [0, 1] to [-1, 1]. If we were to use
-    # a generator, this scale should be done with tanh function
-    if genob.scale:
-        m = scale_matrix(m)
-    return m
+        sample_size=genob.num_samples,
+        Ne=Ne,
+        length=genob.seq_len,
+        mutation_rate=mu,
+        recombination_rate=r,
+        random_seed=seed,
+    )
+
+    return genob._resize_from_ts(ts, rng)
+
 
 class Genobuilder:
     """Class for building genotype matrices from msprime, stdpopsim
@@ -59,7 +63,6 @@ class Genobuilder:
         maf_thresh,
         fixed_dim=128,
         seed=None,
-        scale=False,
         parallelism=0,
         **kwargs,
     ):
@@ -69,7 +72,6 @@ class Genobuilder:
         self._source = source
         self._fixed_dim = fixed_dim
         self._seed = seed
-        self._scale = scale
         self._num_reps = None
         self.parallelism = parallelism
         super(Genobuilder, self).__init__(**kwargs)
@@ -114,10 +116,6 @@ class Genobuilder:
     @property
     def sim_source(self):
         return self._sim_source
-
-    @property
-    def scale(self):
-        return self._scale
 
     @property
     def parallelism(self):
@@ -179,12 +177,16 @@ class Genobuilder:
             p = os.cpu_count()
         self._parallelism = p
 
-    def simulate_msprime(self, params, randomize=False, gauss=False):
+    def simulate_msprime(self, params, randomize=False, proposals=False):
         """Simulate demographic data, returning a tensor with n_reps number
         of genotype matrices"""
+
         rng = random.Random(self.seed)
-        args = [(self, params, randomize, gauss, rng.randrange(1, 2**32))
-                for _ in range(self.num_reps)]
+
+        args = [
+            (self, params, randomize, i, proposals, rng.randrange(1, 2 ** 32))
+            for i in range(self.num_reps)
+        ]
         mat = np.zeros((self.num_reps, self.num_samples, self.fixed_dim))
         ex = executor(self.parallelism)
         timeout = 0.5 * self.num_reps
@@ -237,9 +239,6 @@ class Genobuilder:
             relative_pos = pos_zarr - pos
 
             data[i] = self._resize_from_zarr(hap, relative_pos, alt_zarr)
-
-        if self.scale:
-            data = scale_matrix(data)
 
         data = np.expand_dims(data, axis=-1)
 
@@ -296,17 +295,12 @@ class Genobuilder:
             else:
                 mat[i] = self._resize_from_ts(ts, rng)
 
-        # Scale genotype matrices from [0, 1] to [-1, 1]. If we were to use
-        # a generator, this scale should be done with tanh function
-        if self.scale:
-            mat = scale_matrix(mat)
-
         # Expand dimension by 1 (add channel dim). -1 stands for last axis.
         mat = np.expand_dims(mat, axis=-1)
 
         return mat
 
-    def generate_data(self, num_reps, paramlist=None, gauss=False):
+    def generate_data(self, num_reps, proposals=False):
         # Generate (X, y) data from demographic simulations.
 
         self.num_reps = num_reps
@@ -328,9 +322,7 @@ class Genobuilder:
             gen1 = self.simulate_msprime(self.params)
 
         print(f"generating {num_reps} genotype matrices from msprime")
-        print(paramlist)
-
-        gen0 = self.simulate_msprime(self.params, randomize=True, gauss=gauss)
+        gen0 = self.simulate_msprime(self.params, randomize=True, proposals=proposals)
 
         X = np.concatenate((gen1, gen0))
         y = np.concatenate((np.ones((num_reps)), np.zeros((num_reps))))
@@ -621,10 +613,6 @@ def get_chrom_size(chrom):
     return length[chrom]
 
 
-def scale_matrix(mat):
-    """Scale matrix values within [-1, 1] range"""
-    return mat * 2 / np.max(mat) - 1
-
 
 def draw_genmat(img, name):
 
@@ -780,23 +768,14 @@ if __name__ == "__main__":
     params_dict = OrderedDict()
 
     params_dict["recombination rate"] = Parameter(
-        "recombination rate", -9, -10, (-11, -7), inferable=True, log=True
+        "recombination rate", 1.25e-9, 1e-10, (1e-11, 1e-7), inferable=False
     )
     params_dict["mutation rate"] = Parameter(
-        "mutation rate", -8, -8, (-9, -7), inferable=False, log=True
+        "mutation rate", 1.25e-8, 1e-9, (1e-10, 1e-7), inferable=False
     )
     params_dict["effective size"] = Parameter(
-        "effective size", 4, 4, (3, 5), inferable=True, log=True
+        "effective size", 10000, 14000, (5000, 15000), inferable=True
     )
-
-    """
-    params_dict["recombination rate"] = Parameter(
-        "recombination rate", 1.25e-9, 1e-10, (1e-11, 1e-7), inferable=True)
-    params_dict["mutation rate"] = Parameter(
-            "mutation rate", 1.25e-8, 1e-9, (1e-9, 1e-7), inferable=False)
-    params_dict["effective size"] = Parameter(
-            "effective size", 10000, 14000, (5000, 15000), inferable=True)
-    """
 
     genob = Genobuilder(
         source=args.source,
@@ -805,8 +784,7 @@ if __name__ == "__main__":
         maf_thresh=args.maf_threshold,
         fixed_dim=args.fixed_dimension,
         seed=args.seed,
-        scale=False,
-        parallelism=args.parallelism
+        parallelism=args.parallelism,
     )
 
     if len(params_dict.keys()) >= 1:
@@ -838,4 +816,4 @@ if __name__ == "__main__":
 
 
 # Command example:
-# python genobuilder.py download_genmats -n 1000 -s msprime -nh 99 -l 1e6 -maf 0.05 -f 128 -se 2020 -o test
+# python genobuilder.py download_genmats -n 1000 -s msprime -nh 99 -l 1e6 -maf 0.05 -f 128 -se 2020 -o test -p 16

--- a/genobuilder.py
+++ b/genobuilder.py
@@ -613,7 +613,6 @@ def get_chrom_size(chrom):
     return length[chrom]
 
 
-
 def draw_genmat(img, name):
 
     plt.imshow(img, cmap="winter")

--- a/genomcmcgan.py
+++ b/genomcmcgan.py
@@ -112,7 +112,7 @@ def run_genomcmcgan(
             inferable_params.append(p)
 
     initial_guesses = tf.constant([float(p.initial_guess) for p in inferable_params])
-    step_sizes = tf.constant([float(p.initial_guess*0.1) for p in inferable_params])
+    step_sizes = tf.constant([float(p.initial_guess * 0.1) for p in inferable_params])
     mcmcgan.discriminator.run_eagerly = True
     tf.config.run_functions_eagerly(True)
     mcmcgan.setup_mcmc(
@@ -129,7 +129,7 @@ def run_genomcmcgan(
         start_t = time.time()
 
         sample_mean, sample_stddev, is_accepted, log_acc_rate = mcmcgan.run_chain()
-        #print(f"Is accepted: {is_accepted}, acc_rate: {log_acc_rate}")
+        # print(f"Is accepted: {is_accepted}, acc_rate: {log_acc_rate}")
 
         # Draw traceplot and histogram of collected samples
         mcmcgan.traceplot_samples(inferable_params, it)
@@ -151,7 +151,9 @@ def run_genomcmcgan(
 
         # Prepare the training and validation datasets
         # xtrain, xval, ytrain, yval = mcmcgan.genob.generate_data(n_reps)
-        xtrain, xval, ytrain, yval = mcmcgan.genob.generate_data(num_mcmc_samples, proposals=True)
+        xtrain, xval, ytrain, yval = mcmcgan.genob.generate_data(
+            num_mcmc_samples, proposals=True
+        )
         train_data = tf.data.Dataset.from_tensor_slices(
             (xtrain.astype("float32"), ytrain)
         )

--- a/genomcmcgan.py
+++ b/genomcmcgan.py
@@ -34,8 +34,8 @@ def run_genomcmcgan(
     epochs,
     num_mcmc_samples,
     num_mcmc_burnin,
-    seed=None,
-    parallelism=0,
+    seed,
+    parallelism,
 ):
 
     tf.random.set_seed(seed)
@@ -79,7 +79,7 @@ def run_genomcmcgan(
 
     print("Data simulation finished")
 
-    mcmcgan = MCMCGAN(genob=genob, kernel_name="hmc", seed=seed)
+    mcmcgan = MCMCGAN(genob, kernel_name, seed)
 
     # Load a given discriminator or build one of the implemented ones
     if discriminator_model:
@@ -112,46 +112,46 @@ def run_genomcmcgan(
             inferable_params.append(p)
 
     initial_guesses = tf.constant([float(p.initial_guess) for p in inferable_params])
+    step_sizes = tf.constant([float(p.initial_guess*0.1) for p in inferable_params])
     mcmcgan.discriminator.run_eagerly = True
     tf.config.run_functions_eagerly(True)
     mcmcgan.setup_mcmc(
-        num_mcmc_results=num_mcmc_samples,
-        num_burnin_steps=num_mcmc_burnin,
-        initial_guess=initial_guesses,
+        num_mcmc_samples, num_mcmc_burnin, initial_guesses, step_sizes, 1
     )
 
-    n_reps = 1000
-    max_num_iters = 3
+    max_num_iters = 5
     convergence = False
     it = 1
 
     while not convergence and max_num_iters != it:
 
+        print("Starting the MCMC sampling chain")
         start_t = time.time()
 
-        # Uncalibrated kernels doesn't converge to the desired distribution.
-        # MetropolisHastings(UncalibratedHamiltonianMonteCarlo(...)) is functionally
-        # the same as HamiltonianMonteCarlo(...).
-        print("Starting the MCMC sampling chain")
         sample_mean, sample_stddev, is_accepted, log_acc_rate = mcmcgan.run_chain()
-        print(f"Is accepted: {is_accepted}, acc_rate: {log_acc_rate}")
+        #print(f"Is accepted: {is_accepted}, acc_rate: {log_acc_rate}")
 
         # Draw traceplot and histogram of collected samples
         mcmcgan.traceplot_samples(inferable_params, it)
         mcmcgan.hist_samples(inferable_params, it)
 
-        initial_guesses = []
-        for j, p in enumerate(inferable_params):
-            mean = np.mean(mcmcgan.samples[:, j])
-            std = np.std(mcmcgan.samples[:, j])
-            print(f"{p.name} samples with mean {mean} and std {std}")
-            mcmcgan.genob.params[p.name].set_gauss(mean, std)
-            initial_guesses.append(float(mean))
+        for i, p in enumerate(inferable_params):
+            p.proposals = mcmcgan.samples[:, i].numpy()
 
-        mcmcgan.initial_guess = tf.constant(initial_guesses)
+        means = np.mean(mcmcgan.samples, axis=0)
+        stds = np.std(mcmcgan.samples, axis=0)
+        for j, p in enumerate(inferable_params):
+            print(f"{p.name} samples with mean {means[j]} and std {stds[j]}")
+        mcmcgan.initial_guess = tf.constant(means)
+        # mcmcgan.step_sizes = tf.constant(stds)
+        mcmcgan.step_sizes = tf.constant(np.sqrt(stds))
+        mcmcgan.setup_mcmc(
+            num_mcmc_samples, num_mcmc_burnin, initial_guesses, step_sizes, 1
+        )
 
         # Prepare the training and validation datasets
-        xtrain, xval, ytrain, yval = mcmcgan.genob.generate_data(n_reps, gauss=True)
+        # xtrain, xval, ytrain, yval = mcmcgan.genob.generate_data(n_reps)
+        xtrain, xval, ytrain, yval = mcmcgan.genob.generate_data(num_mcmc_samples, proposals=True)
         train_data = tf.data.Dataset.from_tensor_slices(
             (xtrain.astype("float32"), ytrain)
         )
@@ -161,7 +161,7 @@ def run_genomcmcgan(
         val_data = val_data.cache().batch(batch_size).prefetch(16)
 
         mcmcgan.discriminator.fit(
-            train_data, None, batch_size, epochs, validation_data=val_data, shuffle=True
+            train_data, None, batch_size, epochs, val_data, shuffle=True
         )
 
         it += 1

--- a/mcmcgan.py
+++ b/mcmcgan.py
@@ -5,7 +5,6 @@ import tensorflow as tf
 from tensorflow import keras
 import tensorflow_probability as tfp
 import tensorflow_addons as tfa
-from collections import OrderedDict
 
 from symmetric import Symmetric
 from training_utils import DMonitor, DMonitor2, ConfusionMatrix
@@ -227,6 +226,7 @@ class MCMCGAN:
     def _unnormalized_log_prob(self, x):
 
         import copy
+
         proposals = copy.deepcopy(self.genob.params)
 
         i = 0
@@ -318,7 +318,7 @@ class MCMCGAN:
         is_accepted = None
         log_acc_r = None
         tf_seed = tf.constant(self.seed)
-        print(f'Selected mcmc kernel is {self.kernel_name}')
+        print(f"Selected mcmc kernel is {self.kernel_name}")
 
         if self.kernel_name == "random walk":
             samples = tfp.mcmc.sample_chain(

--- a/mcmcgan.py
+++ b/mcmcgan.py
@@ -5,6 +5,7 @@ import tensorflow as tf
 from tensorflow import keras
 import tensorflow_probability as tfp
 import tensorflow_addons as tfa
+from collections import OrderedDict
 
 from symmetric import Symmetric
 from training_utils import DMonitor, DMonitor2, ConfusionMatrix
@@ -13,7 +14,7 @@ from training_utils import DMonitor, DMonitor2, ConfusionMatrix
 class MCMCGAN:
     """Class for building the coupled MCMC-Discriminator architecture"""
 
-    def __init__(self, genob, kernel_name, discriminator=None, seed=None):
+    def __init__(self, genob, kernel_name, seed=None, discriminator=None):
         super(MCMCGAN, self).__init__()
         self.genob = genob
         self.discriminator = discriminator
@@ -209,7 +210,7 @@ class MCMCGAN:
 
         self.discriminator = cnn
 
-    def D(self, proposals, num_reps=32):
+    def D(self, x, num_reps=32):
         """
         Simulate with parameters `x`, then classify the simulations with the
         discriminator. Returns the average over `num_replicates` simulations.
@@ -218,16 +219,15 @@ class MCMCGAN:
         self.genob.num_reps = num_reps
 
         return tf.reduce_mean(
-            self.discriminator.predict(
-                self.genob.simulate_msprime(proposals).astype("float32")
-            )
+            self.discriminator.predict(self.genob.simulate_msprime(x).astype("float32"))
         )
 
     # Where `D(x)` is the average discriminator output from n independent
     # simulations (which are simulated with parameters `x`).
     def _unnormalized_log_prob(self, x):
 
-        proposals = self.genob.params.copy()
+        import copy
+        proposals = copy.deepcopy(self.genob.params)
 
         i = 0
         for p in proposals:
@@ -235,13 +235,12 @@ class MCMCGAN:
                 if tf.math.less(x[i], proposals[p].bounds[0]) or tf.math.greater(
                     x[i], proposals[p].bounds[1]
                 ):
-                    print("out")
                     # We reject these parameter values by returning probability 0.
                     return -np.inf
                 else:
                     proposals[p].val = x[i]
+                    print(f"{proposals[p].name}: {proposals[p].val}")
 
-                print(f"{proposals[p].name}: {proposals[p].val}")
                 i += 1
 
         score = self.D(proposals)
@@ -256,14 +255,18 @@ class MCMCGAN:
         num_mcmc_results,
         num_burnin_steps,
         initial_guess,
-        step_size=np.float64(1.0),
+        step_sizes,
+        steps_between_results,
     ):
 
         # Initialize the HMC transition kernel.
         self.num_mcmc_results = num_mcmc_results
         self.num_burnin_steps = num_burnin_steps
         self.initial_guess = initial_guess
+        self.step_sizes = step_sizes
+        self.steps_between_results = steps_between_results
         self.samples = None
+        tf.print(self.step_sizes)
 
         if self.kernel_name not in ["random walk", "hmc", "nuts"]:
             raise NameError("kernel value must be either random walk, hmc or nuts")
@@ -276,8 +279,8 @@ class MCMCGAN:
         elif self.kernel_name == "hmc":
             mcmc = tfp.mcmc.HamiltonianMonteCarlo(
                 target_log_prob_fn=self.unnormalized_log_prob,
-                num_leapfrog_steps=3,
-                step_size=step_size,
+                num_leapfrog_steps=6,
+                step_size=self.step_sizes,
             )
 
             self.mcmc_kernel = tfp.mcmc.SimpleStepSizeAdaptation(
@@ -289,7 +292,7 @@ class MCMCGAN:
         elif self.kernel_name == "nuts":
             mcmc = tfp.mcmc.NoUTurnSampler(
                 target_log_prob_fn=self.unnormalized_log_prob,
-                step_size=step_size,
+                step_size=self.step_sizes,
                 max_tree_depth=10,
                 max_energy_diff=1000.0,
             )
@@ -297,6 +300,7 @@ class MCMCGAN:
             self.mcmc_kernel = tfp.mcmc.DualAveragingStepSizeAdaptation(
                 mcmc,
                 num_adaptation_steps=int(self.num_burnin_steps * 0.8),
+                target_accept_prob=0.75,
                 step_size_setter_fn=lambda pkr, new_step_size: pkr._replace(
                     step_size=new_step_size
                 ),
@@ -305,12 +309,16 @@ class MCMCGAN:
             )
 
     # Run the chain (with burn-in).
-    @tf.function
+    # autograph=False is recommended by the TFP team. It is related to how
+    # control-flow statements are handled.
+    # experimental_compile=True for higher efficiency in XLA_GPUs, TPUs, etc...
+    @tf.function(autograph=False, experimental_compile=True)
     def run_chain(self):
 
         is_accepted = None
         log_acc_r = None
         tf_seed = tf.constant(self.seed)
+        print(f'Selected mcmc kernel is {self.kernel_name}')
 
         if self.kernel_name == "random walk":
             samples = tfp.mcmc.sample_chain(
@@ -320,6 +328,7 @@ class MCMCGAN:
                 kernel=self.mcmc_kernel,
                 seed=tf_seed,
                 trace_fn=None,
+                steps_between_results=self.steps_between_results,
             )
 
         elif self.kernel_name in ["hmc", "nuts"]:
@@ -330,6 +339,7 @@ class MCMCGAN:
                 current_state=self.initial_guess,
                 kernel=self.mcmc_kernel,
                 seed=tf_seed,
+                num_steps_between_results=self.steps_between_results,
                 trace_fn=lambda _, pkr: [
                     pkr.inner_results.is_accepted,
                     pkr.inner_results.log_accept_ratio,

--- a/parameter.py
+++ b/parameter.py
@@ -37,7 +37,6 @@ class Parameter:
     def proposals(self, prop):
         self._proposals = prop
 
-
     def prop(self, i):
         return self.proposals[i]
 

--- a/parameter.py
+++ b/parameter.py
@@ -11,6 +11,7 @@ class Parameter:
             self._val = np.float_power(10, val)
         else:
             self._val = val
+        self._proposals = []
         self.bounds = bounds
         self.log = log
         self.initial_guess = initial_guess
@@ -21,6 +22,10 @@ class Parameter:
     def val(self):
         return self._val
 
+    @property
+    def proposals(self):
+        return self._proposals
+
     @val.setter
     def val(self, x):
         if self.log:
@@ -28,28 +33,23 @@ class Parameter:
         else:
             self._val = x
 
-    def set_gauss(self, mean, std):
+    @proposals.setter
+    def proposals(self, prop):
+        self._proposals = prop
 
-        self.gauss_mean = mean
-        self.gauss_std = std
 
-    def rand(self, gauss=False):
+    def prop(self, i):
+        return self.proposals[i]
+
+    def rand(self):
 
         if not self.inferable:
             return self._val
 
-        if gauss:
-            if self.log:
-                return np.float_power(
-                    10, np.random.normal(self.gauss_mean, self.gauss_std)
-                )
-            else:
-                return np.random.normal(self.gauss_mean, self.gauss_std)
-        else:
-            min, max = self.bounds
-            x = np.random.uniform(min, max)
+        min, max = self.bounds
+        x = np.random.uniform(min, max)
 
-            if self.log:
-                return np.float_power(10, x)
-            else:
-                return x
+        if self.log:
+            return np.float_power(10, x)
+        else:
+            return x


### PR DESCRIPTION
- Implemented a different `step_size` value for each demographic parameter, which allows running the mcmc simulations and draw samples on a linear scale (#7).
- Removed the Gaussian trick. The collected values from the mcmc samples are passed directly to generate the genotype matrices with msprime (#9).
- Removed `scale_matrix` utilities (the genotype matrices are scaled in the first batch normalization layer in the discriminator structure).
- Implemented new attribute `proposals` for the `Parameter()` class, to store the mcmc accepted samples for that parameter.
- Use of mcmc argument `num_steps_between_samples` to improve chain mixing and independence of samples.

