### PR TITLE
Introduced sequencing errors | narrow down parameter bounds in each iteration

### DIFF
--- a/demography.py
+++ b/demography.py
@@ -27,7 +27,7 @@ def onepop_constant(args):
         length=genob.seq_len,
         mutation_rate=mu,
         recombination_rate=r,
-        random_seed=genob.seed,
+        #random_seed=genob.seed,
     )
 
     return ts
@@ -68,7 +68,7 @@ def onepop_exp(args):
         length=genob.seq_len,
         mutation_rate=mu,
         recombination_rate=r,
-        random_seed=genob.seed,
+        #random_seed=genob.seed,
     )
 
     return ts
@@ -108,7 +108,7 @@ def onepop_migration(args):
         length=genob.seq_len,
         mutation_rate=mu,
         recombination_rate=r,
-        random_seed=genob.seed,
+        #random_seed=genob.seed,
     )
 
     return ts

--- a/demography.py
+++ b/demography.py
@@ -6,11 +6,10 @@ def onepop_constant(args):
     """Single population model with pop size Ne and constant growth"""
 
     genob, params, randomize, i, proposals = args
-
     necessary_params = ["mu", "r", "Ne"]
-    assert sorted(necessary_params) == sorted(
-        list(params.keys())
-    ), "Invalid combination of parameters. Needed: mu | r | Ne"
+    for p in necessary_params:
+        if p not in list(params.keys()):
+            print("Invalid combination of parameters. Needed: mu | r | Ne")
 
     if proposals:
         mu, r, Ne = [
@@ -40,9 +39,9 @@ def onepop_exp(args):
 
     genob, params, randomize, i, proposals = args
     necessary_params = ["mu", "r", "T1", "N1", "T2", "N2", "growth"]
-    assert sorted(necessary_params) == sorted(
-        list(params.keys())
-    ), "Invalid combination of parameters. Needed: mu | r | T1 | N1 | T2 | N2 | growth"
+    for p in necessary_params:
+        if p not in list(params.keys()):
+            print("Invalid combination of parameters. Needed: mu | r | T1 | N1 | T2 | N2 | growth")
 
     if proposals:
         mu, r, T1, N1, T2, N2, growth = [
@@ -53,7 +52,7 @@ def onepop_exp(args):
         mu, r, T1, N1, T2, N2, growth = [
             params[p].rand() if randomize else params[p].val for p in necessary_params
         ]
-        
+
     N0 = N2 / math.exp(-growth * T2)
 
     # Time is given in generations unit (t/25)
@@ -81,10 +80,9 @@ def onepop_migration(args):
 
     genob, params, randomize, i, proposals = args
     necessary_params = ["mu", "r", "T1", "N1", "N2", "mig"]
-    assert sorted(necessary_params) == sorted(list(params.keys())), (
-        "Invalid combination of parameters. Needed: mu | r | T1 | N1 | N2 | mig \n"
-        f"Obtained: {list(params.keys())}"
-    )
+    for p in necessary_params:
+        if p not in list(params.keys()):
+            print("Invalid combination of parameters. Needed: mu | r | T1 | N1 | N2 | mig")
 
     if proposals:
         mu, r, T1, N1, N2, mig = [

--- a/demography.py
+++ b/demography.py
@@ -27,7 +27,7 @@ def onepop_constant(args):
         length=genob.seq_len,
         mutation_rate=mu,
         recombination_rate=r,
-        #random_seed=genob.seed,
+        # random_seed=genob.seed,
     )
 
     return ts
@@ -41,7 +41,9 @@ def onepop_exp(args):
     necessary_params = ["mu", "r", "T1", "N1", "T2", "N2", "growth"]
     for p in necessary_params:
         if p not in list(params.keys()):
-            print("Invalid combination of parameters. Needed: mu | r | T1 | N1 | T2 | N2 | growth")
+            print(
+                "Invalid combination of parameters. Needed: mu | r | T1 | N1 | T2 | N2 | growth"
+            )
 
     if proposals:
         mu, r, T1, N1, T2, N2, growth = [
@@ -68,7 +70,7 @@ def onepop_exp(args):
         length=genob.seq_len,
         mutation_rate=mu,
         recombination_rate=r,
-        #random_seed=genob.seed,
+        # random_seed=genob.seed,
     )
 
     return ts
@@ -82,7 +84,9 @@ def onepop_migration(args):
     necessary_params = ["mu", "r", "T1", "N1", "N2", "mig"]
     for p in necessary_params:
         if p not in list(params.keys()):
-            print("Invalid combination of parameters. Needed: mu | r | T1 | N1 | N2 | mig")
+            print(
+                "Invalid combination of parameters. Needed: mu | r | T1 | N1 | N2 | mig"
+            )
 
     if proposals:
         mu, r, T1, N1, N2, mig = [
@@ -108,7 +112,7 @@ def onepop_migration(args):
         length=genob.seq_len,
         mutation_rate=mu,
         recombination_rate=r,
-        #random_seed=genob.seed,
+        # random_seed=genob.seed,
     )
 
     return ts

--- a/genobuilder.py
+++ b/genobuilder.py
@@ -32,7 +32,7 @@ def do_sim(args):
     ts = dm.onepop_exp(args)
 
     # Return resized matrix
-    return genob._resize_from_ts(ts)
+    return genob.resize_from_ts(ts)
 
 
 def do_parsing(args):
@@ -54,7 +54,7 @@ def do_parsing(args):
     relative_pos = pos_zarr - pos
 
     # Return resized matrix
-    return genob._resize_from_zarr(hap, relative_pos, alt_zarr)
+    return genob.resize_from_zarr(hap, relative_pos, alt_zarr)
 
 
 class Genobuilder:
@@ -237,7 +237,7 @@ class Genobuilder:
 
         # For each tree sequence output from the simulation
         for i, ts in enumerate(sims):
-            mat[i] = self._resize_from_ts(ts)
+            mat[i] = self.resize_from_ts(ts)
 
         # Expand dimension by 1 (add channel dim). -1 stands for last axis.
         return np.expand_dims(mat, axis=1)
@@ -284,7 +284,7 @@ class Genobuilder:
         mat = np.zeros((self.num_reps, self.num_samples, self.fixed_dim))
 
         # Get lists of randomly selected chromosomes and genomic locations
-        chrom, pos, loc_region = self._random_sampling_geno(callset)
+        chrom, pos, loc_region = self.random_sampling_geno(callset)
         idx = list(range(1, self.num_reps))
         args = [
             [self] * self.num_reps,
@@ -348,14 +348,14 @@ class Genobuilder:
         # Resize from ts, and add sequencing errors if error_prob is given
         for i, ts in enumerate(sims):
             if type(error_prob) is float:
-                mat[i] = self._mutate_geno_old(ts, p=error_prob)
+                mat[i] = self.resize_and_mutate_geno(ts, p=error_prob)
 
             elif type(error_prob) is np.ndarray:
-                mat[i] = self._mutate_geno_old(ts, p=error_prob[i])
+                mat[i] = self.resize_and_mutate_geno(ts, p=error_prob[i])
 
             # No error prob, don't mutate the matrix
             else:
-                mat[i] = self._resize_from_ts(ts)
+                mat[i] = self.resize_from_ts(ts)
 
         # Expand dimension by 1 (add channel dim)
         return np.expand_dims(mat, axis=1)
@@ -403,7 +403,7 @@ class Genobuilder:
         print(f"generating {num_reps} genotype matrices from msprime for testing")
         return self.simulate_msprime(self.params, randomize=True)
 
-    def _mutate_geno(self, ts, p=0.001):
+    def resize_and_mutate_geno(self, ts, p=0.001):
         """Mutate a tree sequence simulation introducing sequencing errors
         with probability p. Then, create and resize a genotype matrix"""
 
@@ -436,7 +436,7 @@ class Genobuilder:
 
         return m
 
-    def _random_sampling_geno(self, callset):
+    def random_sampling_geno(self, callset):
         """Random sampling of a genomic window with the odds weighted by
         chromosome length. If a genomic mask is given, it filters regions with
         low quantity of callable regions"""
@@ -489,7 +489,7 @@ class Genobuilder:
 
         return chroms, pos, slices
 
-    def _resize_from_ts(self, ts):
+    def resize_from_ts(self, ts):
         """Returns a genotype matrix with a fixed number of columns,
         as specified in size"""
 
@@ -516,7 +516,7 @@ class Genobuilder:
 
         return m.astype(float)
 
-    def _resize_from_zarr(self, mat, pos, alts):
+    def resize_from_zarr(self, mat, pos, alts):
         """Resizes a matrix using a sum window, given a genotype matrix,
         positions vector,sequence length and the desired fixed size
         of the new matrix"""
@@ -734,7 +734,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "-m",
         "--mask-file",
-        help="Genomic mask to use for random sampling of VCF files from empirical data",
+        help="Genomic mask to use for filtering empirical genomic data from VCF files",
         default="",
         type=str,
     )

--- a/genobuilder.py
+++ b/genobuilder.py
@@ -30,9 +30,9 @@ def do_sim(args):
     # Perform simulation with chosen demographic model
     genob, params = args[0:2]
     ts = dm.onepop_exp(args)
-    if params['seqerr'].val:
+    if params["seqerr"].inferable:
         # Return resized matrix
-        return genob.resize_and_mutate(ts, params['seqerr'].val)
+        return genob.resize_and_mutate(ts, params["seqerr"].val)
     else:
         return genob.resize_from_ts(ts)
 
@@ -517,6 +517,7 @@ class Genobuilder:
         """Mutate a tree sequence simulation introducing sequencing errors
         with probability p. Then, create and resize a genotype matrix"""
 
+        assert p_error is not None, "p_error is not given"
         m = np.zeros((ts.num_samples, self.fixed_dim), dtype=int)
         ac_thresh = self.maf_thresh * ts.num_samples
 
@@ -524,9 +525,8 @@ class Genobuilder:
 
             genotypes = variant.genotypes
             n = np.random.binomial(len(genotypes), p_error)
-            if n is not None:
-                idx = np.random.randint(0, len(genotypes), size=n)
-                genotypes[idx] = 1 - genotypes[idx]
+            idx = np.random.randint(0, len(genotypes), size=n)
+            genotypes[idx] = 1 - genotypes[idx]
 
             # Filter by MAF
             ac1 = np.sum(genotypes)
@@ -767,7 +767,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
     params_dict = OrderedDict()
 
-
     params_dict["r"] = Parameter(
         "r", 1.25e-8, 1e-9, (1e-10, 1e-7), inferable=False, plotlog=True
     )
@@ -782,7 +781,9 @@ if __name__ == "__main__":
     params_dict["T2"] = Parameter("T2", 500, 1000, (100, 1500), inferable=False)
     params_dict["N2"] = Parameter("N2", 5000, 20000, (1000, 30000), inferable=True)
     params_dict["growth"] = Parameter("growth", 0.01, 0.02, (0, 0.05), inferable=True)
-    params_dict["seqerr"] = Parameter("seqerr", None, 0.001, (0.00001, 0.01), inferable=False)
+    params_dict["seqerr"] = Parameter(
+        "seqerr", None, 0.001, (0.00001, 0.01), inferable=False
+    )
 
     # For onepop_migration model:
     """

--- a/genomcmcgan.py
+++ b/genomcmcgan.py
@@ -110,7 +110,7 @@ def run_genomcmcgan(
         percentiles = np.percentile(mcmcgan.samples, [2.5, 97.5], axis=0)
         for j, p in enumerate(inferable_params):
             print(f"{p.name} samples with mean {means[j]} and std {stds[j]}")
-            p.bounds = tuple(percentiles[:,j])
+            p.bounds = tuple(percentiles[:, j])
 
         inits = means
         step_sizes = stds

--- a/genomcmcgan.py
+++ b/genomcmcgan.py
@@ -75,7 +75,7 @@ def run_genomcmcgan(
     # Obtain initial chain states and initial step sizes, and set up the MCMC
     inits = [p.initial_guess for p in inferable_params]
     step_sizes = [(p.initial_guess * 0.1) for p in inferable_params]
-    mcmcgan.setup_mcmc(num_mcmc_samples, num_mcmc_burnin, inits, step_sizes, 0)
+    mcmcgan.setup_mcmc(num_mcmc_samples, num_mcmc_burnin, inits, step_sizes, 1)
 
     max_num_iters = 5
     convergence = False
@@ -114,7 +114,7 @@ def run_genomcmcgan(
 
         inits = means
         step_sizes = stds
-        mcmcgan.setup_mcmc(num_mcmc_samples, num_mcmc_burnin, inits, step_sizes, 0)
+        mcmcgan.setup_mcmc(num_mcmc_samples, num_mcmc_burnin, inits, step_sizes, 1)
 
         # Generate new batches of real data and updated simulated data
         xtrain, xval, ytrain, yval = mcmcgan.genob.generate_data(

--- a/genomcmcgan.py
+++ b/genomcmcgan.py
@@ -39,7 +39,7 @@ def run_genomcmcgan(
             xtrain, ytrain, xval, yval = pickle.load(obj)
     else:
         xtrain, xval, ytrain, yval = genob.generate_data(num_reps=1000)
-        
+
     # Initialize the MCMCGAN object and the Discriminator
     mcmcgan = MCMCGAN(genob, kernel_name, seed)
     mcmcgan.discriminator = Discriminator()
@@ -107,8 +107,11 @@ def run_genomcmcgan(
         # Calculate means and standard deviation for next MCMC sampling step
         means = np.mean(mcmcgan.samples, axis=0)
         stds = np.std(mcmcgan.samples, axis=0)
+        percentiles = np.percentile(mcmcgan.samples, [2.5, 97.5], axis=0)
         for j, p in enumerate(inferable_params):
             print(f"{p.name} samples with mean {means[j]} and std {stds[j]}")
+            p.bounds = tuple(percentiles[:,j])
+
         inits = means
         step_sizes = stds
         mcmcgan.setup_mcmc(num_mcmc_samples, num_mcmc_burnin, inits, step_sizes, 0)

--- a/mcmcgan.py
+++ b/mcmcgan.py
@@ -213,7 +213,7 @@ class MCMCGAN:
         for i, p in enumerate(params):
             sns.distplot(self.samples[:, i], color=colors[i])
             ymax = plt.ylim()[1]
-            if self.genob.source == 'msprime':
+            if self.genob.source == "msprime":
                 plt.vlines(p.val, 0, ymax, color=colors[i])
             plt.ylim(0, ymax)
             plt.legend([p.name])
@@ -237,7 +237,7 @@ class MCMCGAN:
         plt.clf()
         for i, p in enumerate(params):
             plt.plot(self.samples[:, i], c=colors[i], alpha=0.3)
-            if self.genob.source == 'msprime':
+            if self.genob.source == "msprime":
                 plt.hlines(
                     p.val,
                     0,

--- a/mcmcgan.py
+++ b/mcmcgan.py
@@ -213,7 +213,8 @@ class MCMCGAN:
         for i, p in enumerate(params):
             sns.distplot(self.samples[:, i], color=colors[i])
             ymax = plt.ylim()[1]
-            plt.vlines(p.val, 0, ymax, color=colors[i])
+            if self.genob.source == 'msprime':
+                plt.vlines(p.val, 0, ymax, color=colors[i])
             plt.ylim(0, ymax)
             plt.legend([p.name])
             plt.xlabel("Values")
@@ -236,14 +237,15 @@ class MCMCGAN:
         plt.clf()
         for i, p in enumerate(params):
             plt.plot(self.samples[:, i], c=colors[i], alpha=0.3)
-            plt.hlines(
-                p.val,
-                0,
-                len(self.samples),
-                zorder=4,
-                color=colors[i],
-                label="${}$".format(i),
-            )
+            if self.genob.source == 'msprime':
+                plt.hlines(
+                    p.val,
+                    0,
+                    len(self.samples),
+                    zorder=4,
+                    color=colors[i],
+                    label="${}$".format(i),
+                )
             plt.legend([p.name])
             plt.xlabel("Accepted samples")
             plt.ylabel("Values")

--- a/vcf2zarr.py
+++ b/vcf2zarr.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
         "--vcf-files",
         help="Path pointing to the first of the VCF files to be parsed. "
         "The files can be zipped as .gz. Data transfer is quicker when "
-        "the files are indexed with Tabix, ending in .tbi.",
+        "the files are indexed with Tabix, with an index file ending in .tbi.",
         type=str,
     )
 


### PR DESCRIPTION
I introduced sequencing errors as an inferable parameter, with probability `p_error` in `resize_and_mutate()` function. It will come in handy when we are estimating parameters from empirical data.

Also, I use the 2.5 and 97.5 quantiles for each parameter posterior distribution as min and max values to narrow down the parameter bounds in each training iteration. I am still not very convinced of this new characteristic and may delete it in future updates, when I get more results to compare.